### PR TITLE
[Fix] filePath가 길어질 때의 오류 해결

### DIFF
--- a/src/main/java/com/mju/management/domain/post/domain/PostFile.java
+++ b/src/main/java/com/mju/management/domain/post/domain/PostFile.java
@@ -20,10 +20,13 @@ public class PostFile {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length=1000)
     private String fileName;
 
+    @Column(length=1000)
     private String filePath;
 
+    @Column(length=1000)
     private String s3key;
 
     @Nullable


### PR DESCRIPTION
파일 이름이 길면 VARCHAR(255)를 넘어 에러발생하는 문제 해결